### PR TITLE
[FIX] pos_partner_deselection: перезапускаем таймер при смене экрана

### DIFF
--- a/pos_partner_deselection/__manifest__.py
+++ b/pos_partner_deselection/__manifest__.py
@@ -3,7 +3,7 @@
     "summary": """The module deselects a partner in opened POS on expiry the predefined time interval after the customer was set.""",  # noqa: E501
     "category": "Point of Sale",
     "images": ["images/pos_partner_deselection.jpg"],
-    "version": "17.0.1.0.0",
+    "version": "17.0.1.0.1",
     "application": False,
     "author": "IT-Projects LLC",
     "support": "it@it-projects.info",

--- a/pos_partner_deselection/static/src/js/partner_deselection.js
+++ b/pos_partner_deselection/static/src/js/partner_deselection.js
@@ -2,38 +2,58 @@ odoo.define("pos_partner_deselection.partner_deselection", [], function (require
     "use strict";
 
     const {Order} = require("@point_of_sale/app/store/models");
+    const {PosStore} = require("@point_of_sale/app/store/pos_store");
     const {patch} = require("@web/core/utils/patch");
+
+    patch(PosStore.prototype, {
+        showScreen() {
+            super.showScreen(...arguments);
+            this.setPartnerDeselectTimer();
+        },
+
+        setPartnerDeselectTimer() {
+            clearTimeout(this.partnerDeselectTimer);
+            if (this.shouldResetPartnerDeselectTimer(this.selectedOrder)) {
+                this.partnerDeselectTimer = setTimeout(
+                    () => this.deselectPartner(),
+                    this.config.customer_deselection_interval * 1000
+                );
+            }
+        },
+
+        shouldResetPartnerDeselectTimer(order) {
+            return (
+                this.mainScreen?.component?.name !== "TicketScreen" &&
+                this.config.customer_deselection_interval &&
+                order &&
+                order.partner &&
+                !order.to_invoice
+            );
+        },
+
+        deselectPartner() {
+            if (!this.selectedOrder.finalized && !this.selectedOrder.to_invoice) {
+                this.selectedOrder.set_partner(null);
+            }
+        },
+    });
 
     patch(Order.prototype, {
         setup() {
             super.setup(...arguments);
-            if (this.partner) {
+            if (this.pos.shouldResetPartnerDeselectTimer(this)) {
                 this.set_partner(null);
             }
         },
 
-        setupCustomerDeselection(interval) {
-            if (this.partner_deselect_timer) {
-                clearTimeout(this.partner_deselect_timer);
-            }
-            this.partner_deselect_timer = setTimeout(() => {
-                if (!this.finalized) {
-                    this.set_partner(null);
-                }
-            }, interval * 1000);
+        set_partner() {
+            super.set_partner(...arguments);
+            this.pos.setPartnerDeselectTimer();
         },
 
-        set_partner(partner) {
-            super.set_partner(...arguments);
-
-            const customer_deselection_interval =
-                this.pos.config.customer_deselection_interval;
-
-            if (customer_deselection_interval && partner && !this.finalized) {
-                this.setupCustomerDeselection(customer_deselection_interval);
-            } else if (!partner && this.partner_deselect_timer) {
-                clearTimeout(this.partner_deselect_timer);
-            }
+        set_to_invoice() {
+            super.set_to_invoice(...arguments);
+            this.pos.setPartnerDeselectTimer();
         },
     });
 });


### PR DESCRIPTION
Также учитываем следующие ситуации перед запуском таймера снятия клиента

1. Если выставлен to invoice, то не запускаем таймер
2. В экране списка заказов не запускаем таймер